### PR TITLE
fix append ambiguity

### DIFF
--- a/src/inotify.adb
+++ b/src/inotify.adb
@@ -253,12 +253,17 @@ package body Inotify is
                                  if Object.Moves.Length = Object.Moves.Capacity then
                                     Object.Moves.Delete_First;
                                  end if;
-                                 Object.Moves.Append ((Event.Cookie,
-                                   (From => SU.To_Unbounded_String (Directory & "/" & Name),
-                                    To   => <>)));
-                                 --  If inode is moved to outside watched directory,
-                                 --  then there will never be a Moved_To or Moved_Self
-                                 --  if instance is not recursive
+                                 declare
+                                    MP : Cookie_Move_Pair := 
+                                          (Event.Cookie, 
+                                             (From => SU.To_Unbounded_String (Directory & "/" & Name),
+                                              To   => <>));
+                                 begin
+                                    Object.Moves.Append (MP);
+                                    --  If inode is moved to outside watched directory,
+                                    --  then there will never be a Moved_To or Moved_Self
+                                    --  if instance is not recursive
+                                 end;
                               when Moved_To =>
                                  declare
                                     Cursor : Move_Vectors.Cursor := Find_Move (Event.Cookie);


### PR DESCRIPTION
When trying to build `orka-awt` I get:
```
...
ⓘ Building orka_awt=1.0.0/orka_awt-x11.gpr (1/2)...
Compile
   [Ada]          awt-inputs-gamepads.adb
...
inotify.adb:256:46: error: ambiguous call to "Append"
inotify.adb:256:46: error: possible interpretation at a-cobove.ads:282, instance at inotify.ads:199
inotify.adb:256:46: error: possible interpretation at a-cobove.ads:292, instance at inotify.ads:199

   compilation of awt-inputs-gamepads.adb failed
```
I propose changes to be explicit.